### PR TITLE
Add simple stub for own documents page

### DIFF
--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -7,6 +7,7 @@ import { HomePage } from '@pages/HomePage/HomePage';
 import { Page1 } from '@pages/Page1/Page1';
 import { AdminPage } from '@pages/AdminPage/AdminPage';
 import { ForbiddenPage } from '@pages/ForbiddenPage/ForbiddenPage';
+import { OwnDocumentsPage } from '@pages/OwnDocumentsPage/OwnDocumentsPage';
 
 const AppRoutes: FC = () => {
   return (
@@ -24,7 +25,7 @@ const AppRoutes: FC = () => {
         }
       >
         <Route index element={<HomePage />} />
-
+        <Route path="myDocuments" element={<OwnDocumentsPage />} />
         <Route
           path="page1"
           element={

--- a/src/components/CreateDocumentButton/CreateDocumentButton.tsx
+++ b/src/components/CreateDocumentButton/CreateDocumentButton.tsx
@@ -1,0 +1,9 @@
+import { type FC } from 'react';
+
+// to use somewhere else?
+interface ButtonProps {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+export const CreateDocumentButton: FC<ButtonProps> = ({ onClick }) => {
+  return <button onClick={onClick}>Создать новый документ...</button>;
+};

--- a/src/components/CreateDocumentForm/CreateDocumentForm.tsx
+++ b/src/components/CreateDocumentForm/CreateDocumentForm.tsx
@@ -1,0 +1,41 @@
+import type { FC } from 'react';
+
+interface CreateDocumentFormProps {
+  onSubmit: (
+    attributeValues: Array<{ attributeId: number; attributeValue: string }>,
+  ) => void;
+  onCancel: () => void;
+}
+
+export const CreateDocumentForm: FC<CreateDocumentFormProps> = ({
+  onSubmit,
+  onCancel,
+}) => {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit([
+          { attributeId: 1, attributeValue: 'a1' },
+          { attributeId: 2, attributeValue: 'dsjfh' },
+        ]);
+      }}
+      style={{ border: 'solid' }}
+    >
+      Это форма для создания документа. Тут будут отображаться атрибуты и прочая
+      нужная инфа.
+      {['attr1', 'attr2'].map((attr) => (
+        <div key={attr}>{attr}</div>
+      ))}
+      <button type="submit">Ок</button>
+      <button
+        type="button"
+        onClick={() => {
+          onCancel();
+        }}
+      >
+        Отмена
+      </button>
+    </form>
+  );
+};

--- a/src/components/CreateDocumentWidget/CreateDocumentWidget.tsx
+++ b/src/components/CreateDocumentWidget/CreateDocumentWidget.tsx
@@ -1,0 +1,30 @@
+import { useState, type FC } from 'react';
+// import { currentUserStore } from '@store/index';
+import { CreateDocumentButton } from '@components/CreateDocumentButton/CreateDocumentButton';
+import { CreateDocumentForm } from '@components/CreateDocumentForm/CreateDocumentForm';
+
+export const CreateDocumentWidget: FC = () => {
+  const [isMinimized, setIsMinimized] = useState<boolean>(true);
+  if (isMinimized)
+    return (
+      <CreateDocumentButton
+        onClick={() => {
+          setIsMinimized(false);
+        }}
+      />
+    );
+  return (
+    <CreateDocumentForm
+      onSubmit={(attributeValues) => {
+        console.log(
+          'Тут будет вызываться метод сохранения документа',
+          attributeValues,
+        );
+        setIsMinimized(true); // После ответа от сервера
+      }}
+      onCancel={() => {
+        setIsMinimized(true);
+      }}
+    />
+  );
+};

--- a/src/components/OwnDocumentCard/OwnDocumentCard.tsx
+++ b/src/components/OwnDocumentCard/OwnDocumentCard.tsx
@@ -1,0 +1,22 @@
+import { type FC } from 'react';
+
+import type IDocument from '@entities/IDocument';
+
+interface OwnDocumentProps {
+  document: IDocument;
+}
+
+export const OwnDocument: FC<OwnDocumentProps> = ({ document }) => {
+  return (
+    <div
+      style={{
+        border: 'solid black 1px',
+        width: '200px',
+        height: '50px',
+        margin: '10px',
+      }}
+    >
+      <h3>{document.name}</h3>
+    </div>
+  );
+};

--- a/src/entities/IDocument.ts
+++ b/src/entities/IDocument.ts
@@ -1,0 +1,4 @@
+export default interface IDocument {
+  id: number;
+  name: string;
+}

--- a/src/entities/IOrganization.ts
+++ b/src/entities/IOrganization.ts
@@ -1,0 +1,5 @@
+export default interface IOrganization {
+  id: number;
+  name: string;
+  inn: string;
+}

--- a/src/entities/IUser.ts
+++ b/src/entities/IUser.ts
@@ -1,0 +1,21 @@
+export default interface IUser {
+  id: number;
+  fullName: string;
+  dateOfBirth: string;
+  email: string;
+  phone: string;
+  post: string;
+  role: string;
+  userPassportDto: {
+    passportSeries: string;
+    passportNumber: string;
+    passportIssued: string;
+    passportDate: string;
+    passportKp: string;
+  };
+  orgDto: {
+    id: number;
+    name: string;
+    inn: string;
+  };
+}

--- a/src/pages/OwnDocumentsPage/OwnDocumentsPage.tsx
+++ b/src/pages/OwnDocumentsPage/OwnDocumentsPage.tsx
@@ -1,0 +1,21 @@
+import { type FC } from 'react';
+import { documentsStore } from '@store/index';
+import { OwnDocument } from '@components/OwnDocumentCard/OwnDocumentCard';
+import { CreateDocumentWidget } from '@components/CreateDocumentWidget/CreateDocumentWidget';
+
+export const OwnDocumentsPage: FC = () => {
+  return (
+    <>
+      <div>
+        Страница отображения документов пользователя (тех, которые он создал). В
+        будущем нужно обернуть в проверку роли.
+      </div>
+      <main>
+        <CreateDocumentWidget />
+        {documentsStore.ownDocuments.map((d) => (
+          <OwnDocument key={d.id} document={d}></OwnDocument>
+        ))}
+      </main>
+    </>
+  );
+};


### PR DESCRIPTION
## Описание изменений

Добавил страницу с простой структурой из компонентов заглушек. Дальше можно: 1)переводить на MUI, 2)Цеплять данные из стора.

## Тип изменений

- [ ] Исправление ошибки
- [X] Новая функциональность
- [ ] Изменение существующей функциональности
- [ ] Прочее (уточните)

## Yougile:
- [#CLFP-17](https://ru.yougile.com/team/28e9c2bed7c5/#CLFP-17)

## Скриншоты

![image](https://github.com/VictorPozdeev1/CaseLab-ECM/assets/114474092/7cb4c875-1183-4c8d-88d4-3386716ee6f0)

## Доп. инфо
Страница доступна по роуту /mydocuments