### PR TITLE
Add blanks for company-users-administration pages

### DIFF
--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -9,6 +9,8 @@ import { Page1 } from '@pages/Page1/Page1';
 import { AdminPage } from '@pages/AdminPage/AdminPage';
 import { ForbiddenPage } from '@pages/ForbiddenPage/ForbiddenPage';
 import { OwnDocumentsPage } from '@pages/OwnDocumentsPage/OwnDocumentsPage';
+import { MyCompanyAdministrationPage } from '@pages/MyCompanyAdministrationPage/MyCompanyAdministrationPage';
+import { SpecificCompanyAdministrationPage } from '@pages/SpecificCompanyAdministrationPage/SpecificCompanyAdministrationPage';
 import { UsersPage } from '@pages/UsersPage';
 import { Page404 } from '@pages/Page404';
 
@@ -52,6 +54,22 @@ const AppRoutes: FC = () => {
       <Route path="forbidden" element={<ForbiddenPage />} />
       <Route path="*" element={<Page404 />} />
       <Route path="users" element={<UsersPage />} />
+      <Route
+        path="myCompany"
+        element={
+          <RequireRoleCheck role="COMPANY_ADMIN">
+            <MyCompanyAdministrationPage />
+          </RequireRoleCheck>
+        }
+      />
+      <Route
+        path="company/:companyId"
+        element={
+          <RequireRoleCheck role="SYSTEM_ADMIN">
+            <SpecificCompanyAdministrationPage />
+          </RequireRoleCheck>
+        }
+      />
     </Routes>
   );
 };

--- a/src/pages/MyCompanyAdministrationPage/MyCompanyAdministrationPage.tsx
+++ b/src/pages/MyCompanyAdministrationPage/MyCompanyAdministrationPage.tsx
@@ -1,0 +1,11 @@
+import { type FC } from 'react';
+
+import { CompanyUsersAdministration } from '@widgets/CompanyUsersAdministration/CompanyUsersAdministration';
+import sessionStore from '@store/session';
+import Spinner from '@shared/components/Spinner/Spinner';
+
+export const MyCompanyAdministrationPage: FC = () => {
+  const companyId = sessionStore.userData?.organizationId;
+  if (typeof companyId !== 'number') return <Spinner />; // Или не принимать undefined?
+  return <CompanyUsersAdministration companyId={companyId} />;
+};

--- a/src/pages/SpecificCompanyAdministrationPage/SpecificCompanyAdministrationPage.tsx
+++ b/src/pages/SpecificCompanyAdministrationPage/SpecificCompanyAdministrationPage.tsx
@@ -1,0 +1,12 @@
+import { type FC } from 'react';
+
+import { CompanyUsersAdministration } from '@widgets/CompanyUsersAdministration/CompanyUsersAdministration';
+import { useParams } from 'react-router-dom';
+
+export const SpecificCompanyAdministrationPage: FC = () => {
+  const { companyId: companyIdString } = useParams();
+  const companyId = Number(companyIdString);
+  if (Number.isNaN(companyId))
+    return <div>Не существует организации с id = {companyIdString}</div>;
+  return <CompanyUsersAdministration companyId={companyId} />;
+};

--- a/src/widgets/CompanyUsersAdministration/CompanyUsersAdministration.tsx
+++ b/src/widgets/CompanyUsersAdministration/CompanyUsersAdministration.tsx
@@ -1,0 +1,19 @@
+import { type FC } from 'react';
+
+// import { currentUserStore } from '@store/index';
+// import { usersStore } from '@store/index';
+import { observer } from 'mobx-react-lite';
+
+export const CompanyUsersAdministration: FC<{ companyId: number }> = observer(
+  ({ companyId }) => {
+    return (
+      <div>
+        <h2>
+          Это страница пользователей, относящихся к организации с id={companyId}
+        </h2>
+        Тут будет список пользователей компании, где можно редачить их, задавать
+        пароль, итд.
+      </div>
+    );
+  },
+);


### PR DESCRIPTION
## Описание изменений
Заготовки для страниц управления пользователями
## Тип изменений
- [X] Новая функциональность
## Yougile:
- [#CLFP-34](https://ru.yougile.com/team/28e9c2bed7c5/#CLFP-34)

## Скриншоты
![image](https://github.com/VictorPozdeev1/CaseLab-ECM/assets/114474092/7f3b96ad-d7a8-42d8-a4a8-cd2b80f2f09d)
![image](https://github.com/VictorPozdeev1/CaseLab-ECM/assets/114474092/4b30e083-b26b-4d4c-93e4-d4cab4466aac)


## Дополнительная информация
1)Странички эти - именно админские. Для пользователей пока не предполагается показывать список других пользователей.
(Будет форма поиска пользователя. чтоб отослать ему документ - но это другое.)
2)Т.к. это виджет, отображающий пользователей из одной организации, то столбец "Организация" в таблице не нужен.
