### PR TITLE
Update users administration widget and add simple store for companies

### DIFF
--- a/src/entities/company/model/CompaniesStore.ts
+++ b/src/entities/company/model/CompaniesStore.ts
@@ -1,0 +1,29 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+
+import { Service as api } from '@api';
+import { Company } from './Company';
+
+class CompaniesStore {
+  companies: Company[] = [];
+  constructor() {
+    makeAutoObservable(this, {});
+  }
+
+  async _loadCompanies(): Promise<void> {
+    // content должен быть required, как я понимаю
+    // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
+    const newCompaniesList = (await api.getAllOrgs()).content!.map(
+      (o) => new Company(o),
+    );
+    runInAction(() => {
+      this.companies = newCompaniesList;
+    });
+  }
+
+  getNameById(id: number): string | undefined {
+    return this.companies.find((c) => c.id === id)?.name;
+  }
+}
+
+export const companiesStore = new CompaniesStore();
+void companiesStore._loadCompanies();

--- a/src/entities/company/model/Company.ts
+++ b/src/entities/company/model/Company.ts
@@ -1,0 +1,15 @@
+import { type OrgDto } from '@api';
+
+export class Company {
+  constructor(apiResponse: OrgDto) {
+    this.id = apiResponse.id;
+    this.name = apiResponse.name;
+    this.inn = apiResponse.inn;
+    this.defaultRecipientId = apiResponse.defaultRecipient;
+  }
+
+  id: number;
+  name: string;
+  inn: string;
+  defaultRecipientId: number;
+}

--- a/src/entities/company/model/index.ts
+++ b/src/entities/company/model/index.ts
@@ -1,0 +1,2 @@
+export { Company } from './Company';
+export { companiesStore } from './CompaniesStore';

--- a/src/pages/MyCompanyAdministrationPage/MyCompanyAdministrationPage.tsx
+++ b/src/pages/MyCompanyAdministrationPage/MyCompanyAdministrationPage.tsx
@@ -1,10 +1,7 @@
 import { type FC } from 'react';
 
-import { CompanyUsersAdministration } from '@widgets/CompanyUsersAdministration/CompanyUsersAdministration';
-import sessionStore from '@store/session';
+import { MyCompanyUsersAdministration } from '@widgets/CompanyUsersAdministration';
 
 export const MyCompanyAdministrationPage: FC = () => {
-  return (
-    <CompanyUsersAdministration companyId={sessionStore.currentUserCompanyId} />
-  );
+  return <MyCompanyUsersAdministration />;
 };

--- a/src/pages/SpecificCompanyAdministrationPage/SpecificCompanyAdministrationPage.tsx
+++ b/src/pages/SpecificCompanyAdministrationPage/SpecificCompanyAdministrationPage.tsx
@@ -1,6 +1,6 @@
 import { type FC } from 'react';
 
-import { CompanyUsersAdministration } from '@widgets/CompanyUsersAdministration/CompanyUsersAdministration';
+import { CustomCompanyUsersAdministration } from '@widgets/CompanyUsersAdministration';
 import { useParams } from 'react-router-dom';
 
 export const SpecificCompanyAdministrationPage: FC = () => {
@@ -8,5 +8,5 @@ export const SpecificCompanyAdministrationPage: FC = () => {
   const companyId = Number(companyIdString);
   if (Number.isNaN(companyId))
     return <div>Не существует организации с id = {companyIdString}</div>;
-  return <CompanyUsersAdministration companyId={companyId} />;
+  return <CustomCompanyUsersAdministration companyId={companyId} />;
 };

--- a/src/processes/RequirePermissionCheck/RequirePermissionCheck.tsx
+++ b/src/processes/RequirePermissionCheck/RequirePermissionCheck.tsx
@@ -8,10 +8,10 @@ import { type Permissions } from '@store/session';
 const RequirePermissionCheck: FC<{
   permission: Permissions;
   children: JSX.Element;
-}> = observer(({ permission: role, children }) => {
+}> = observer(({ permission, children }) => {
   const currentLocation = useLocation();
 
-  if (!currentSessionStore.permissions.includes(role)) {
+  if (!currentSessionStore.permissions.includes(permission)) {
     return (
       <Navigate to="/Forbidden" state={{ previousLocation: currentLocation }} />
     );

--- a/src/store/session.ts
+++ b/src/store/session.ts
@@ -22,6 +22,7 @@ const rolesPermissions: Record<Roles, Permissions[]> = {
     Permissions.SYSTEM_ADMIN,
     Permissions.DOCUMENT_TYPES,
     Permissions.MY_COMPANY_CONTROL_PANEL,
+    Permissions.CUSTOM_COMPANY_CONTROL_PANEL,
   ],
   COMPANY_ADMIN: [
     Permissions.COMPANY_ADMIN,

--- a/src/widgets/CompanyUsersAdministration/CompanyUsersAdministration.tsx
+++ b/src/widgets/CompanyUsersAdministration/CompanyUsersAdministration.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type FC, useState } from 'react';
+import { type FC, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { Box, Button, Container, Typography } from '@mui/material';
 import { type PasswordDto, Service } from '@api';
@@ -8,134 +8,121 @@ import {
   UserPasswordForm,
 } from '@entities/user/components/UserPasswordForm/UserPasswordForm';
 import { UsersTable } from './UsersTable';
-import userStores, { type UserStore } from './model';
+import { type CompanyUsersModel } from './model';
 
-export const CompanyUsersAdministration: FC<{ companyId: number }> = observer(
-  ({ companyId }) => {
-    const [model, setModel] = useState<UserStore>(
-      userStores.getUserStoreForCompany(companyId),
-    );
-    useEffect(() => {
-      const model = userStores.getUserStoreForCompany(companyId);
-      setModel(model);
-      void model.loadCompanyUsers(companyId);
-    }, [companyId]);
+export const CompanyUsersAdministration: FC<{
+  title: string;
+  model: CompanyUsersModel;
+}> = observer(({ title, model }) => {
+  const [userFormProps, setUserFormProps] = useState<UserFormProps>();
+  const [userPassFormProps, setPassFormProps] = useState<UserPassFormProps>();
+  const users = model.users;
+  if (users === undefined) return <div>users === undefined</div>; // Loader?
 
-    const [userFormProps, setUserFormProps] = useState<UserFormProps>();
-    const [userPassFormProps, setPassFormProps] = useState<UserPassFormProps>();
-    const users = model.users;
-    if (users === undefined) return <div>users === undefined</div>; // Loader?
+  const addUserClickHandler = (): void => {
+    setUserFormProps({
+      userInitialInfo: new User(),
+      onCancel: () => {
+        setUserFormProps(undefined);
+      },
+      onSubmit: (userData: User) => {
+        /* Заблокировать форму */
+        model
+          .addUser(userData)
+          .then() /* Закрыть форму */
+          .catch(() => {}) /* Оставить форму открытой и показать ошибку */
+          .finally(); /* Разблокировать форму */
+        setUserFormProps(undefined);
+      },
+    });
+  };
 
-    const addUserClickHandler = (): void => {
-      setUserFormProps({
-        userInitialInfo: new User(),
-        onCancel: () => {
-          setUserFormProps(undefined);
-        },
-        onSubmit: (userData: User) => {
-          /* Заблокировать форму */
-          model
-            .addUser(userData)
-            .then() /* Закрыть форму */
-            .catch(() => {}) /* Оставить форму открытой и показать ошибку */
-            .finally(); /* Разблокировать форму */
-          setUserFormProps(undefined);
-        },
-      });
-    };
+  const editUserClickHandler = (userToEditId: number): void => {
+    setUserFormProps({
+      userInitialInfo: model.users.find((u) => u.id === userToEditId) as User,
+      onCancel: () => {
+        setUserFormProps(undefined);
+      },
+      onSubmit: (userData: User) => {
+        /* Заблокировать форму */
+        model
+          .updateUser(userData)
+          .then() /* Закрыть форму */
+          .catch(() => {}) /* Оставить форму открытой и показать ошибку */
+          .finally(); /* Разблокировать форму */
+        setUserFormProps(undefined);
+      },
+    });
+  };
 
-    const editUserClickHandler = (userToEditId: number): void => {
-      setUserFormProps({
-        userInitialInfo: model.users.find((u) => u.id === userToEditId) as User,
-        onCancel: () => {
-          setUserFormProps(undefined);
-        },
-        onSubmit: (userData: User) => {
-          /* Заблокировать форму */
-          model
-            .updateUser(userData)
-            .then() /* Закрыть форму */
-            .catch(() => {}) /* Оставить форму открытой и показать ошибку */
-            .finally(); /* Разблокировать форму */
-          setUserFormProps(undefined);
-        },
-      });
-    };
+  const editUserClickPass = (userToEditId: number): void => {
+    setPassFormProps({
+      userInitialInfo: model.users.find((u) => u.id === userToEditId) as User,
+      onCancel: () => {
+        setPassFormProps(undefined);
+      },
+      onSubmit: (password: string) => {
+        /* Заблокировать форму */
+        Service.setUserPassword(userToEditId, {
+          password,
+        } as unknown as PasswordDto)
+          .then() /* Закрыть форму */
+          .catch(() => {}) /* Оставить форму открытой и показать ошибку */
+          .finally();
+        setPassFormProps(undefined);
+      },
+    });
+  };
 
-    const editUserClickPass = (userToEditId: number): void => {
-      setPassFormProps({
-        userInitialInfo: model.users.find((u) => u.id === userToEditId) as User,
-        onCancel: () => {
-          setPassFormProps(undefined);
-        },
-        onSubmit: (password: string) => {
-          /* Заблокировать форму */
-          Service.setUserPassword(userToEditId, {
-            password,
-          } as unknown as PasswordDto)
-            .then() /* Закрыть форму */
-            .catch(() => {}) /* Оставить форму открытой и показать ошибку */
-            .finally();
-          setPassFormProps(undefined);
-        },
-      });
-    };
-
-    return (
-      <>
-        <Container maxWidth={'lg'}>
-          <Box padding={'16px'}>
-            <Box
-              marginBottom={'28px'}
-              display={'flex'}
-              alignItems={'center'}
-              gap={'16px'}
-            >
-              <Typography variant="h5" fontWeight={'bold'}>
-                {/* todo
-                 Тут будет написано либо "моей организации", либо "организации <Название>".
-                 Но это быстро не сделать, сделаю позже.
-                 (надо, чтоб виджет знал о своём типе, и модель тоже - и обращалась к разным эндпойнтам.)
-                */}
-                Список сотрудников организации с id = {companyId} (доделать!)
-              </Typography>
-            </Box>
-            <Box sx={{ mb: '1rem' }}>
-              <Button
-                type="submit"
-                variant="contained"
-                color="primary"
-                sx={{
-                  textTransform: 'none',
-                  width: 'fit-content',
-                  height: '40px',
-                  boxShadow: 'none',
-                  borderRadius: '20px',
-                  minWidth: '40px',
-                  ':hover': {
-                    boxShadow: 'none',
-                  },
-                  ':disabled': {
-                    boxShadow: 'none',
-                  },
-                }}
-                onClick={addUserClickHandler}
-              >
-                <Typography>Добавить сотрудника</Typography>
-              </Button>
-            </Box>
-            <UsersTable
-              users={users}
-              onEditUserClick={editUserClickHandler}
-              onEditUserClickPass={editUserClickPass}
-            />
+  return (
+    <>
+      <Container maxWidth={'lg'}>
+        <Box padding={'16px'}>
+          <Box
+            marginBottom={'28px'}
+            display={'flex'}
+            alignItems={'center'}
+            gap={'16px'}
+          >
+            <Typography variant="h5" fontWeight={'bold'}>
+              {title}
+            </Typography>
           </Box>
-        </Container>
-        {userFormProps !== undefined && <UserForm {...userFormProps} />}
-        {userPassFormProps !== undefined && (
-          <UserPasswordForm {...userPassFormProps} />
-        )}
-      </>
-    );
-  },
-);
+          <Box sx={{ mb: '1rem' }}>
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              sx={{
+                textTransform: 'none',
+                width: 'fit-content',
+                height: '40px',
+                boxShadow: 'none',
+                borderRadius: '20px',
+                minWidth: '40px',
+                ':hover': {
+                  boxShadow: 'none',
+                },
+                ':disabled': {
+                  boxShadow: 'none',
+                },
+              }}
+              onClick={addUserClickHandler}
+            >
+              <Typography>Добавить сотрудника</Typography>
+            </Button>
+          </Box>
+          <UsersTable
+            users={users}
+            onEditUserClick={editUserClickHandler}
+            onEditUserClickPass={editUserClickPass}
+          />
+        </Box>
+      </Container>
+      {userFormProps !== undefined && <UserForm {...userFormProps} />}
+      {userPassFormProps !== undefined && (
+        <UserPasswordForm {...userPassFormProps} />
+      )}
+    </>
+  );
+});

--- a/src/widgets/CompanyUsersAdministration/CustomCompanyUsersAdministration.tsx
+++ b/src/widgets/CompanyUsersAdministration/CustomCompanyUsersAdministration.tsx
@@ -1,0 +1,30 @@
+import { useEffect, type FC, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+
+import { companiesStore } from '@entities/company/model';
+import userStores, { type CompanyUsersModel } from './model';
+import { CompanyUsersAdministration } from './CompanyUsersAdministration';
+
+export const CustomCompanyUsersAdministration: FC<{ companyId: number }> =
+  observer(({ companyId }) => {
+    const [model, setModel] = useState<CompanyUsersModel>(
+      userStores.getCustomCompanyUsersStore(companyId),
+    );
+
+    // Может быть, это и не нужно?
+    useEffect(() => {
+      const model = userStores.getCustomCompanyUsersStore(companyId);
+      setModel(model);
+    }, [companyId]);
+
+    const companyName = companiesStore.getNameById(companyId);
+
+    return (
+      <CompanyUsersAdministration
+        title={`Список сотрудников организации: ${
+          companyName ?? 'id=' + companyId
+        }`}
+        model={model}
+      />
+    );
+  });

--- a/src/widgets/CompanyUsersAdministration/CustomCompanyUsersAdministration.tsx
+++ b/src/widgets/CompanyUsersAdministration/CustomCompanyUsersAdministration.tsx
@@ -8,12 +8,12 @@ import { CompanyUsersAdministration } from './CompanyUsersAdministration';
 export const CustomCompanyUsersAdministration: FC<{ companyId: number }> =
   observer(({ companyId }) => {
     const [model, setModel] = useState<CompanyUsersModel>(
-      userStores.getCustomCompanyUsersStore(companyId),
+      userStores.getCustomCompanyUserStore(companyId),
     );
 
     // Может быть, это и не нужно?
     useEffect(() => {
-      const model = userStores.getCustomCompanyUsersStore(companyId);
+      const model = userStores.getCustomCompanyUserStore(companyId);
       setModel(model);
     }, [companyId]);
 

--- a/src/widgets/CompanyUsersAdministration/MyCompanyUsersAdministration.tsx
+++ b/src/widgets/CompanyUsersAdministration/MyCompanyUsersAdministration.tsx
@@ -1,0 +1,19 @@
+import { type FC, useMemo } from 'react';
+import { observer } from 'mobx-react-lite';
+
+import userStores, { type CompanyUsersModel } from './model';
+import { CompanyUsersAdministration } from './CompanyUsersAdministration';
+
+export const MyCompanyUsersAdministration: FC = observer(() => {
+  const model = useMemo<CompanyUsersModel>(
+    () => userStores.myCompanyUsersStore,
+    [],
+  );
+
+  return (
+    <CompanyUsersAdministration
+      title={`Список сотрудников моей организации`}
+      model={model}
+    />
+  );
+});

--- a/src/widgets/CompanyUsersAdministration/index.ts
+++ b/src/widgets/CompanyUsersAdministration/index.ts
@@ -1,0 +1,2 @@
+export { CustomCompanyUsersAdministration } from './CustomCompanyUsersAdministration';
+export { MyCompanyUsersAdministration } from './MyCompanyUsersAdministration';

--- a/src/widgets/CompanyUsersAdministration/model.ts
+++ b/src/widgets/CompanyUsersAdministration/model.ts
@@ -57,7 +57,7 @@ export class CompanyUsersModel {
   }
 }
 
-class Companies {
+class UsersByCompanies {
   constructor() {
     makeAutoObservable(this);
   }
@@ -67,7 +67,7 @@ class Companies {
     CompanyUsersModel
   >();
 
-  getCustomCompanyUsersStore(companyId: number): CompanyUsersModel {
+  getCustomCompanyUserStore(companyId: number): CompanyUsersModel {
     let result = this._usersByCompany.get(companyId);
     if (result === undefined) {
       result = new CompanyUsersModel();
@@ -93,4 +93,4 @@ class Companies {
   }
 }
 
-export default new Companies();
+export default new UsersByCompanies();

--- a/src/widgets/CompanyUsersAdministration/model.ts
+++ b/src/widgets/CompanyUsersAdministration/model.ts
@@ -1,19 +1,25 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 
-import { Service as api, type UserCreateDto, type UserUpdateDto } from '@api';
+import {
+  Service as api,
+  type UserReplyDto,
+  type UserCreateDto,
+  type UserUpdateDto,
+} from '@api';
 import { User } from '@entities/user';
+import sessionStore from '@store/session';
 
-export class UserStore {
+export class CompanyUsersModel {
   constructor() {
     makeAutoObservable(this);
   }
 
   users: User[] = [];
 
-  async loadCompanyUsers(companyId: number): Promise<void> {
-    const newUserList = (await api.getUsersByOrganization(companyId)).map(
-      (u) => new User(u),
-    );
+  async _loadCompanyUsers(
+    usersLoader: () => Promise<UserReplyDto[]>,
+  ): Promise<void> {
+    const newUserList = (await usersLoader()).map((u) => new User(u));
     runInAction(() => {
       this.users = newUserList;
     });
@@ -26,8 +32,9 @@ export class UserStore {
       passportDate: new Date().toISOString(),
       passportIssued: new Date().toISOString(),
       passportKp: '333999',
-      passportNumber: '345987',
+      passportNumber: (Date.now() % 1000000).toString(),
       passportSeries: '3453',
+      // Возможно, стоило бы проставлять здесь companyId
     };
     const response = await api.updateUser(newData.id, requestDto);
     const index = this.users.findIndex((u) => u.id === newData.id);
@@ -41,29 +48,49 @@ export class UserStore {
       passportDate: new Date().toISOString(),
       passportIssued: new Date().toISOString(),
       passportKp: '333999',
-      passportNumber: '345987',
+      passportNumber: (Date.now() % 1000000).toString(),
       passportSeries: '3453',
+      // Возможно, стоило бы проставлять здесь companyId
     };
     const response = await api.createUser(requestDto);
     runInAction(() => this.users.push(new User(response)));
   }
 }
 
-class UsersByCompanies {
+class Companies {
   constructor() {
     makeAutoObservable(this);
   }
 
-  _usersByCompany: Map<number, UserStore> = new Map<number, UserStore>();
+  _usersByCompany: Map<number, CompanyUsersModel> = new Map<
+    number,
+    CompanyUsersModel
+  >();
 
-  getUserStoreForCompany(companyId: number): UserStore {
+  getCustomCompanyUsersStore(companyId: number): CompanyUsersModel {
     let result = this._usersByCompany.get(companyId);
     if (result === undefined) {
-      result = new UserStore();
+      result = new CompanyUsersModel();
+      void result._loadCompanyUsers(() =>
+        api.getUsersByOrganization(companyId),
+      );
+      this._usersByCompany.set(companyId, result);
+    }
+    return result;
+  }
+
+  get myCompanyUsersStore(): CompanyUsersModel {
+    const companyId = sessionStore.currentUserCompanyId;
+    let result = this._usersByCompany.get(companyId);
+    if (result === undefined) {
+      result = new CompanyUsersModel();
+      void result._loadCompanyUsers(() =>
+        api.getUsersByOrganization(companyId),
+      );
       this._usersByCompany.set(companyId, result);
     }
     return result;
   }
 }
 
-export default new UsersByCompanies();
+export default new Companies();


### PR DESCRIPTION
## Описание изменений

- Переделал виджет CompanyUsersAdministration вместе с его моделью так, чтобы они разделяли, работают ли они со своей компанией или с кастомной. Теперь в заголовке виджета выводится имя компании (ну или пишется: "Моя компания"). 
- Добавлен простой стор для компаний (пока что из него просто их имена берутся).
- Немного подправлен список разрешений по ролям.

## Скриншоты

![image](https://github.com/VictorPozdeev1/CaseLab-ECM/assets/114474092/14289fc6-a446-4194-aa79-a84ad808eb6e)